### PR TITLE
Support for different auth providers for developers and end users

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -23,7 +23,12 @@ class Settings(BaseSettings):
     ] = "https://developer.sandbox.ioxio-dataspace.com/resources"
 
     DATASPACE_BASE_DOMAIN: str = "sandbox.ioxio-dataspace.com"
-    AUTHENTICATION_PROVIDER_URL: HttpUrl = "https://login.sandbox.ioxio-dataspace.com"
+    AUTHENTICATION_PROVIDER_DEVELOPER_URL: HttpUrl = (
+        "https://login.sandbox.ioxio-dataspace.com"
+    )
+    AUTHENTICATION_PROVIDER_END_USER_URL: HttpUrl = (
+        "https://login.sandbox.ioxio-dataspace.com"
+    )
     CONSENT_PROVIDER_URL: HttpUrl = "https://consent.sandbox.ioxio-dataspace.com"
     WEBSITE_URL: HttpUrl = "https://sandbox.ioxio-dataspace.com"
     DATASPACE_DOCS_URL: HttpUrl = "https://docs.sandbox.ioxio-dataspace.com"

--- a/src/consent_request_token.py
+++ b/src/consent_request_token.py
@@ -42,7 +42,7 @@ class Body(BaseModel):
     subiss: str = Field(
         ...,
         description="The `iss` from the ID Token of the user.",
-        examples=[conf.AUTHENTICATION_PROVIDER_URL],
+        examples=[conf.AUTHENTICATION_PROVIDER_END_USER_URL],
     )
     acr: str = Field(
         ...,
@@ -57,7 +57,7 @@ class Body(BaseModel):
     appiss: str = Field(
         ...,
         description="The `iss` (OIDC issuer) at which the app is registered.",
-        examples=[conf.AUTHENTICATION_PROVIDER_URL],
+        examples=[conf.AUTHENTICATION_PROVIDER_END_USER_URL],
     )
     aud: str = Field(
         ...,
@@ -104,10 +104,10 @@ class ConsentRequestToken(BaseModel):
                     "body": {
                         "iss": "https://example.com",
                         "sub": "debade8a-091d-42da-9b0c-e61f9471e2c3",
-                        "subiss": conf.AUTHENTICATION_PROVIDER_URL,
+                        "subiss": conf.AUTHENTICATION_PROVIDER_END_USER_URL,
                         "acr": conf.ACR_VALUES,
                         "app": "bb8c7f74-0855-42e1-ba09-70bb27103ded",
-                        "appiss": conf.AUTHENTICATION_PROVIDER_URL,
+                        "appiss": conf.AUTHENTICATION_PROVIDER_END_USER_URL,
                         "aud": conf.CONSENT_PROVIDER_URL,
                         "exp": 1678492800,
                         "iat": 1678406400,

--- a/src/consent_token.py
+++ b/src/consent_token.py
@@ -64,7 +64,7 @@ class Body(BaseModel):
     subiss: str = Field(
         ...,
         description="The `iss` from the ID Token of the user.",
-        examples=[conf.AUTHENTICATION_PROVIDER_URL],
+        examples=[conf.AUTHENTICATION_PROVIDER_END_USER_URL],
     )
     acr: str = Field(
         ...,
@@ -79,7 +79,7 @@ class Body(BaseModel):
     appiss: str = Field(
         ...,
         description="The `iss` (OIDC issuer) at which the app is registered.",
-        examples=[conf.AUTHENTICATION_PROVIDER_URL],
+        examples=[conf.AUTHENTICATION_PROVIDER_END_USER_URL],
     )
     dsi: AnyUrl = Field(
         ...,
@@ -134,10 +134,10 @@ class ConsentToken(BaseModel):
                     "body": {
                         "iss": conf.CONSENT_PROVIDER_URL,
                         "sub": "debade8a-091d-42da-9b0c-e61f9471e2c3",
-                        "subiss": conf.AUTHENTICATION_PROVIDER_URL,
+                        "subiss": conf.AUTHENTICATION_PROVIDER_END_USER_URL,
                         "acr": conf.ACR_VALUES,
                         "app": "bb8c7f74-0855-42e1-ba09-70bb27103ded",
-                        "appiss": conf.AUTHENTICATION_PROVIDER_URL,
+                        "appiss": conf.AUTHENTICATION_PROVIDER_END_USER_URL,
                         "dsi": f"dpp://source@{conf.DATASPACE_BASE_DOMAIN}/"
                         "draft/Weather/Current/Metric",
                         "exp": 1678492800,

--- a/src/dataspace_configuration.py
+++ b/src/dataspace_configuration.py
@@ -5,13 +5,38 @@ from pydantic import BaseModel, Field, HttpUrl
 from settings import conf
 
 
-class AuthenticationProviders(BaseModel):
+class AuthenticationProviderDetailsDeveloper(BaseModel):
     base_url: HttpUrl = Field(
         ...,
-        examples=[conf.AUTHENTICATION_PROVIDER_URL],
+        examples=[conf.AUTHENTICATION_PROVIDER_DEVELOPER_URL],
         description="Base URL for the authentication provider. Appending "
         "`/.well-known/openid-configuration` will give the full URL to the "
         "openid-configuration.",
+    )
+
+
+class AuthenticationProviderDetailsEndUser(BaseModel):
+    base_url: HttpUrl = Field(
+        ...,
+        examples=[conf.AUTHENTICATION_PROVIDER_END_USER_URL],
+        description="Base URL for the authentication provider. Appending "
+        "`/.well-known/openid-configuration` will give the full URL to the "
+        "openid-configuration.",
+    )
+
+
+class AuthenticationProviders(BaseModel):
+    developer: AuthenticationProviderDetailsDeveloper = Field(
+        ...,
+        examples=[{"base_url": conf.AUTHENTICATION_PROVIDER_DEVELOPER_URL}],
+        description="Details about authentication provider used to identify developers "
+        "on the dataspace.",
+    )
+    end_user: AuthenticationProviderDetailsEndUser = Field(
+        ...,
+        examples=[{"base_url": conf.AUTHENTICATION_PROVIDER_END_USER_URL}],
+        description="Details about authentication provider used to identify end users "
+        "on the dataspace.",
     )
 
 
@@ -56,9 +81,14 @@ class DataspaceConfiguration(BaseModel):
                     "developer_portal_url": conf.DEVELOPER_PORTAL_URL,
                     "docs_url": conf.DATASPACE_DOCS_URL,
                     "dataspace_name": conf.DATASPACE_NAME,
-                    "authentication_providers": [
-                        {"base_url": conf.AUTHENTICATION_PROVIDER_URL}
-                    ],
+                    "authentication_providers": {
+                        "developer": {
+                            "base_url": conf.AUTHENTICATION_PROVIDER_DEVELOPER_URL
+                        },
+                        "end_user": {
+                            "base_url": conf.AUTHENTICATION_PROVIDER_END_USER_URL
+                        },
+                    },
                     "consent_providers": [{"base_url": conf.CONSENT_PROVIDER_URL}],
                     "definitions": {
                         "git": conf.DEFINITIONS_GIT_URL,
@@ -99,7 +129,7 @@ class DataspaceConfiguration(BaseModel):
         description="A human readable name for the dataspace",
         examples=[conf.DATASPACE_NAME],
     )
-    authentication_providers: List[AuthenticationProviders]
+    authentication_providers: AuthenticationProviders
     consent_providers: List[ConsentProviders]
     definitions: Definitions
 


### PR DESCRIPTION
Update dataspace configuration to support having different authentication providers for end users and developers on the same dataspace.